### PR TITLE
Fix the date and time of the format of the article

### DIFF
--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -3,7 +3,7 @@
 <article class="preview">
     <header>
         <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-        <div class="post-meta"><time datetime="{{ .Now.Format "01 JANUARY 2006" }}">{{ .Now.Format "01 JANUARY 2006" }}</time></div>
+        <div class="post-meta"><time datetime="{{ .Date.Format "02 January 2006" }}">{{ .Date.Format "02 January 2006" }}</time></div>
     </header>
     <section class="post-excerpt">
         <a class="excerptlink" href="{{ .Permalink }}"><p>{{ .Description | markdownify }}&hellip;</p></a>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -8,7 +8,7 @@
 	    <article class="post">
 	        <header>
 	        <h1 class="post-title">{{ .Title }}</h1>
-	        <div class="post-meta"><time datetime="{{ .Now.Format "01 JANUARY 2006" }}">{{ .Now.Format "01 JANUARY 2006" }}</time></div>
+	        <div class="post-meta"><time datetime="{{ .Date.Format "02 January 2006" }}">{{ .Date.Format "02 January 2006" }}</time></div>
 	        </header>
 
 	        <section class="post-content">


### PR DESCRIPTION
- Use the posting date of the article instead of the current.
- Fix the date format using the Go format.

---

ex.)
- Frontmatter
  
  ```
  +++
  date = "2015-05-18T13:36:15Z"
  title = "chpwd_functions"
  description = "Zsh で一時的に chpwd の hook を無効にしたいときは"
  +++
  ```
- before
  
  ![before](https://cloud.githubusercontent.com/assets/7157/9729150/485a4f10-5648-11e5-9e70-599c71c96655.png)
- after
  
  ![after](https://cloud.githubusercontent.com/assets/7157/9729157/55d5eca8-5648-11e5-895e-198d11b06657.png)
