### PR TITLE
Use HTTPS for clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Inside the folder of your Hugo site run:
 
     $ mkdir themes
     $ cd themes
-    $ git clone git@github.com:digitalcraftsman/hugo-steam-theme.git
+    $ git clone https://github.com/digitalcraftsman/hugo-steam-theme.git
 
 For more information read the official [setup guide](//gohugo.io/overview/installing/) of Hugo.
 


### PR DESCRIPTION
The `git@github.com` URLs require authentication, so users without write access
to this repository must use the HTTP endpoints provided by Github.

```
$ git clone git@github.com:digitalcraftsman/hugo-steam-theme.git
Cloning into 'hugo-steam-theme'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
