### PR TITLE
Fix the error of repeated homepage title.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html" charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-    <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
+    <title>{{ $isHome := eq .Title .Site.Title }}{{ .Title }}{{ if eq $isHome false }} - {{ .Site.Title }}{{ end }}</title>
     <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
     <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
     {{ .Hugo.Generator }}


### PR DESCRIPTION
The SiteTitle appeared twice in homepage title. 
I fix it.
