### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,7 +10,7 @@
 		    {{ with .Site.Params.gitlab }}
 		    <a href="//gitlab.com/u/{{ . }}" target="_blank" title="GitLab"><i class="fa fa-2x fa-fw fa-gitlab"></i> <span class="hidden">GitLab</span></a>&nbsp;
 		    {{ end }}
-		    <a href="{{ .RSSlink }}" target="_blank" title="RSS"><i class="fa fa-2x fa-fw fa-rss"></i> <span class="hidden">RSS</span></a>
+		    <a href="{{ .RSSLink }}" target="_blank" title="RSS"><i class="fa fa-2x fa-fw fa-rss"></i> <span class="hidden">RSS</span></a>
 		</section>
 
 		<section class="copyright">&copy; {{.Now.Format "2006"}} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.name }}</a>. {{ .Site.Params.copyright | markdownify }}</section>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,10 +13,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 
     {{ "<!-- RSS autodiscovery -->" | safeHTML }}
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml"
+    {{ if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml"
     title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml"
+    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml"
     title="{{ .Site.Title }}" />
     {{ end }}
 


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.