### PR TITLE
change to a lowercase 'c' in themecolor (exampleSite/config.toml)

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,7 +14,7 @@ paginate = 10
 	copyright = "Released under the MIT license."
 
 	# You can choose between green, orange, red and blue.
-	themeColor = "green"
+	themecolor = "green"
 
 	# Link custom assets relative to /static
 	favicon   = "favicon.ico"


### PR DESCRIPTION
This line from layouts/partials/head.html is looking for themecolor in all lowercase: 

    {{ partial (printf "themes/%s-theme" .Site.Params.themecolor) . }}