### PR TITLE
Should fix #17

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,10 @@ paginate = 10
 
 	# You can choose between green, orange, red and blue.
 	themecolor = "green"
+	
+	# Use Hugo's summary in post list when no description is provided in taml header? 
+	# If false, ellipsis (...) is shown instead.
+	useSummaryIfNoDescription = true
 
 	# Link custom assets relative to /static
 	favicon   = "favicon.ico"


### PR DESCRIPTION
The missing parameter `useSummaryIfNoDescription` basically disables the use of Hugo-created summaries in the post overview because of a conditional in `summary.html` that cannot evaluate true. This parameter chould be in the `config.taml` by default to avoid confusing users.